### PR TITLE
fix: release notify to slack

### DIFF
--- a/.github/workflows/release-and-deploy.yaml
+++ b/.github/workflows/release-and-deploy.yaml
@@ -78,6 +78,7 @@ jobs:
       - name: Slack notification
         uses: 8398a7/action-slack@v3
         with:
+          job_name: release notification
           status: custom
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
           custom_payload: |
@@ -91,7 +92,6 @@ jobs:
               ]
             }
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
         if: always()


### PR DESCRIPTION
### [0.0.6](https://github.com/nexters-landlords/deo.checkhaebang.com/compare/v0.0.5...v0.0.6) (2020-09-26)


### Bug Fixes

* release notify to slack ([1c60150](https://github.com/nexters-landlords/deo.checkhaebang.com/commit/1c601503c2dfe899f012bf438d5f997df8d64b4f))